### PR TITLE
Add ADR for database schema management strategy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+indent_size = 2
 
 [*.java]
 indent_style = space

--- a/docs/adr/0001-hibernate-update-then-flyway.md
+++ b/docs/adr/0001-hibernate-update-then-flyway.md
@@ -1,32 +1,43 @@
 # ADR: Database Schema Management Strategy
 
 ## Status
+
 Accepted
 
 ## Context
+
 We are building a Spring Boot application that uses JPA/Hibernate for persistence.
-Hibernate provides an option (`spring.jpa.hibernate.ddl-auto=update`) to automatically adjust the database schema to match entity definitions.
-Alternatively, tools like Flyway or Liquibase offer explicit, versioned migration scripts for controlled schema evolution.
+Hibernate provides an option (`spring.jpa.hibernate.ddl-auto=update`) to automatically adjust the database schema to
+match entity definitions.
+Alternatively, tools like Flyway or Liquibase offer explicit, versioned migration scripts for controlled schema
+evolution.
 
 ## Decision
-We will **start with Hibernate `ddl-auto=update`** during the early development phase to accelerate iteration and reduce setup overhead.
-Once the schema stabilizes and the project requires reproducibility across environments, we will **introduce Flyway** for versioned, controlled migrations.
+
+We will **start with Hibernate `ddl-auto=update`** during the early development phase to accelerate iteration and reduce
+setup overhead.
+Once the schema stabilizes and the project requires reproducibility across environments, we will **introduce Flyway**
+for versioned, controlled migrations.
 At that point, Hibernate’s automatic schema update will be disabled (`ddl-auto=none`).
 
 ## Consequences
+
 - **Short-term benefits:**
-    - Faster development and prototyping.
-    - No need to manage migration scripts initially.
+  - Faster development and prototyping.
+  - No need to manage migration scripts initially.
 - **Long-term benefits:**
-    - Migration history and reproducibility with Flyway.
-    - Safer schema evolution across environments.
+  - Migration history and reproducibility with Flyway.
+  - Safer schema evolution across environments.
 - **Risks:**
-    - Potential inconsistencies if relying too long on Hibernate `update`.
-    - Manual effort required to establish a baseline migration when transitioning to Flyway.
+  - Potential inconsistencies if relying too long on Hibernate `update`.
+  - Manual effort required to establish a baseline migration when transitioning to Flyway.
 
 ## Alternatives Considered
+
 - **Always use Hibernate `update`:** Simple, but lacks reproducibility and control in production.
-- **Start with Flyway immediately:** Provides safety and history from day one, but adds setup overhead during rapid prototyping.
+- **Start with Flyway immediately:** Provides safety and history from day one, but adds setup overhead during rapid
+  prototyping.
 
 ## Notes
+
 This hybrid approach balances **speed in early development** with **safety and reproducibility in later stages**.


### PR DESCRIPTION
This pull request introduces an Architecture Decision Record (ADR) outlining the transition from Hibernate's `ddl-auto=update` to Flyway for database schema management. This transition aims to provide better version control and safer schema updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record describing the database schema management approach, current use of automatic schema updates, planned transition to versioned migrations, and trade-offs/risks.

* **Style**
  * Introduced a global editor configuration change to standardize default indentation to 2 spaces (with specific language exceptions retained).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->