### PR TITLE
feat: added docker-compose.yml for local dev mimicing production env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,64 @@
+networks:
+  app-net:
+    driver: bridge
+
 services:
-  mysql:
-    image: mysql:8.4
-
+  kafka:
+    image: confluentinc/cp-kafka:8.1.0
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: backend
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      CLUSTER_ID: 5L6g3nShT-eMCtK--X86sw
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OPTS: "-Xms512m -Xmx512m"
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    networks:
+      - app-net
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
+  mysql:
+    image: mysql:8.0  # Matches InnoDBCluster compatibility
+    hostname: mysql
+    container_name: mysql
     ports:
       - "3306:3306"
-
+    environment:
+      MYSQL_ROOT_PASSWORD: rootPassword
+      MYSQL_DATABASE: appdb
+      MYSQL_USER: appuser
+      MYSQL_PASSWORD: apppass123
+      MYSQL_ROOT_HOST: '%'
     volumes:
-      - mysql-data:/var/lib/mysql
+      - mysql-data:/var/lib/mysql  #
+    networks:
+      - app-net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: --default-authentication-plugin=mysql_native_password
 
 volumes:
+  kafka-data:
   mysql-data:


### PR DESCRIPTION
## Pull Request Type
- [x] Feature (a new feature for the project)
- [ ] Fix (a bug fix)
- [ ] Chore (no production code change)
- [ ] Refactor (refactoring production code)
- [x] Docs (documentation changes)
- [ ] Style (formatting only)
- [ ] Test (adding/refactoring tests)

## Description
This PR adds a ready-to-use `docker-compose.yml` that starts a **single-node Kafka (KRaft)** and **MySQL** instance, perfectly suited for local development and is inline with our production environment. Authentication for Kafka will be added in a upcoming PR once the project is more comprehensive.

### Key Features
- **Kafka Service** – single-node KRaft broker + controller (identical code path to prod), plaintext listeners, replication factor = 1 and min.insync.replicas = 1 for instant startup.
- **MySQL Service** – MySQL 8.0 with pre-created database `appdb` and user `appuser`.
- **Shared Docker network** – **During production,** the Spring Boot app can reach services via `kafka:9092` and `mysql:3306`.
- **No external files or secrets** – everything is self-contained (prod overrides come from k8s Secrets anyway).
- **IntelliJ friendly** – works out of the box with IntelliJ’s built-in Docker integration (Docker Desktop / Docker Desktop for Linux / Docker Engine + IntelliJ Docker plugin).

## How Has This Been Tested?
- `docker compose up -d` → both services healthy in < 25 s
- Kafka topic creation works:
  `docker exec -it kafka kafka-topics --bootstrap-server localhost:9092 --create --topic test`
- Kafka created topic exists:
  `docker exec -it kafka kafka-topics --bootstrap-server localhost:9092 --list`
- MySQL connection works:
  `docker exec -it mysql mysql -uroot -prootPassword -e "SHOW DATABASES;"`
- Spring Boot application started from IntelliJ connects successfully to both services using the Docker connection.

## How developers use it (most of you are on IntelliJ)
1. **Start the stack** (once per working session)
   ```bash
   docker compose up -d
   ```

2. **In IntelliJ**
   - Make sure the Docker tool window is connected (Docker Desktop or Docker Engine).
   - IntelliJ automatically sees the `docker-compose.yml` in the project.
   - The services appear under **Services → docker-compose.yml** as `kafka` and `mysql`.

3. **Application configuration for local development** (add or edit a run configuration)  
   **No manual changes needed!**  
   The application now uses sensible defaults automatically when run locally:
   ```properties
   spring.kafka.bootstrap-servers=localhost:9092
   spring.datasource.url=jdbc:mysql://localhost:3306/appdb?useSSL=false&allowPublicKeyRetrieval=true
   spring.datasource.username=appuser
   spring.datasource.password=apppass123
   ```
   These are set in `application.properties` via environment-variable placeholders with fallbacks:
   ```properties
   spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/appdb?useSSL=false&allowPublicKeyRetrieval=true}
   spring.datasource.username=${SPRING_DATASOURCE_USERNAME:appuser}
   spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:apppass123}
   spring.kafka.bootstrap-servers=${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
   ```

4. **Production**  
   No action required before merging. In Kubernetes the values are overridden automatically by the Deployment (DB URL from the `mysql-url` secret, username/password from the existing `mysql-auth` secret, Kafka from the cluster service).

5. **Run / Debug** your Spring Boot app as usual (green play button).  
   IntelliJ uses its internal Docker connection, so no `localhost` forwarding or port conflicts occur.

6. **Stop / clean**
   ```bash
   docker compose down # stop containers, keep data
   docker compose down -v # stop and delete volumes (fresh start)
   ```

## Linked issues
This PR closes issue #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kafka service for message queue processing
  * Upgraded MySQL database to version 8.0
  * Implemented dedicated storage volumes for data persistence
  * Configured network infrastructure for improved service communication
  * Enhanced service reliability with health checks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->