### PR TITLE
fix: fixed null Docker tags with delayed env var assignment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 	environment {
 		DOCKER_REGISTRY = '192.168.0.82:5000'
 		APP_NAME = 'zipp'
-		DOCKER_IMAGE = "${DOCKER_REGISTRY}/${APP_NAME}:${GIT_COMMIT_SHORT}"
 		DOCKER_IMAGE_LATEST = "${DOCKER_REGISTRY}/${APP_NAME}:latest"
 		GIT_REPO_URL = 'https://github.com/fungover/zipp'
 		GIT_BRANCH = 'main'
@@ -57,9 +56,8 @@ pipeline {
 				])
 				script {
 					def fullCommit = env.GIT_COMMIT ?: sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-					env.GIT_COMMIT_SHORT = fullCommit.take(7) 
+					env.GIT_COMMIT_SHORT = fullCommit.take(7)
 					env.DOCKER_IMAGE = "${DOCKER_REGISTRY}/${APP_NAME}:${GIT_COMMIT_SHORT}"
-					env.DOCKER_IMAGE_LATEST = "${DOCKER_REGISTRY}/${APP_NAME}:latest"
 					echo "DEBUG: GIT_COMMIT=${fullCommit}, GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT}, DOCKER_IMAGE=${DOCKER_IMAGE}"
 				}
 				publishChecks name: PROGRESS_CHECK_NAME, title: PROGRESS_CHECK_TITLE, status: 'QUEUED', summary: PROGRESS_CHECK_SUMMARY


### PR DESCRIPTION
## Pull Request Type
- [ ] Feature (a new feature for the project)
- [x] Fix (a bug fix)
- [ ] Chore (no production code change)
- [ ] Refactor (refactoring production code)
- [ ] Docs (documentation changes)
- [ ] Style (formatting only)
- [ ] Test (adding/refactoring tests)

## Description
This PR fixes the persistent null tag issue in Docker images by delaying the DOCKER_IMAGE environment variable assignment (to avoid early interpolation before GIT_COMMIT_SHORT is set) and using Jenkins' built-in GIT_COMMIT variable for reliable commit hashing. This ensures valid tags even in detached HEAD or shallow clone scenarios, preventing errors in build, scan, and push stages.

### Key Features
- **Delayed DOCKER_IMAGE Assignment** – Moves the env var set after GIT_COMMIT_SHORT is defined, avoiding null from early null interpolation.
- **Reliable Commit Hashing with GIT_COMMIT** – Uses Jenkins' GIT_COMMIT env var (full hash, shortened to 7 chars) with a fallback git rev-parse, eliminating flakiness from git commands in PR/merges.
### How Has This Been Tested?
The merging of this PR to main and verify if the deployment works will be the test.

## Linked issues
This PR closes issue #59