### PR TITLE
Handle Github merge queue branches in Jenkins Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,7 @@ pipeline {
 		jdk 'jdk-25'
 	}
 	options {
-		script {
-			if (env.BRANCH_NAME == 'main') {
-				disableConcurrentBuilds()
-			}
-		}
+		disableConcurrentBuilds()
 	}
 	environment {
 		DOCKER_REGISTRY = '192.168.0.82:5000'


### PR DESCRIPTION
## Pull Request Description

### Pull Request Type
- [ ] Feature (a new feature for the project)
- [x] Fix (a bug fix)
- [ ] Chore (no production code change)
- [ ] Refactor (refactoring production code)
- [ ] Docs (documentation changes)
- [ ] Style (formatting only)
- [ ] Test (adding/refactoring tests)

### Description
This PR updates the Jenkins pipeline to handle GitHub merge queue temporary branches (e.g., "gh-readonly-queue/main/pr-...") by treating them as equivalent to 'main' for deployment-related stages. This ensures pre-merge validation includes deployment without skipping key steps. Uses `expression` with `startsWith` regex in `when` conditions for stages like 'Try Reuse PR Image', 'Generate Kubernetes Manifests', and 'Deploy to Kubernetes via SSH'. Also incorporates conditional `disableConcurrentBuilds()` for 'main' in options.

### Key Changes
- Added regex checks (e.g., `env.BRANCH_NAME.startsWith('gh-readonly-queue/main/')`) to `when` blocks for main-like behavior on merge queue branches.
- Updated post-build summary logic to use the same check for checkName and summary.
- Added options block with conditional disableConcurrentBuilds on main.

### How Has This Been Tested?
The merging of this PR to main and verify if the deployment works will be the test.

### Linked Issues
Closes issue #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to recognize merge-queue branch prefixes as equivalent to main for build, tag, push and deploy paths.
  * Disabled concurrent builds on main for improved stability.
  * Updated gating and final reporting so merge-queue branches are treated like main for deployability and status summaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->