### PR TITLE
Fix(config): Restrict .env config import to dev properties only

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -10,7 +10,7 @@ logging.level.root=INFO
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.security=DEBUG
 # env
-spring.config.import=file:.env[.properties]
+spring.config.import=optional:file:.env[.properties]git
 # Security
 server.servlet.session.cookie.same-site=lax
 server.servlet.session.cookie.secure=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -19,8 +19,6 @@ spring.jpa.show-sql=false
 # Logging
 logging.level.root=INFO
 
-spring.config.import=file:.env[.properties]
-
 # Security
 server.servlet.session.cookie.same-site=lax
 server.servlet.session.cookie.secure=true


### PR DESCRIPTION
This PR fixes an issue where the application attempted to load a local .env file in environments where it does not even exist.
The .env file is only relevant for local development, so when running tests and deploying it leads to failures.
We do not even have a env.file in our project- so I actually made the import optional to play it safe. 

The .env config is now restricted to the dev properties only - preventing future startup failures in test and production environments. 

Result: The application starts correctly in all environments!

PS: This change was initially committed to main by mistake, which gave me a good opportunity to practice cherry-picking, stashing and force-pushing before moving it to the correct branch created for this issue.
If there are any problems, please let me know!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Development environment configuration now handles missing files gracefully without blocking application startup
* Production configuration simplified by removing explicit environment property import requirement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->