### PR TITLE
Issue/93 add event replay

### DIFF
--- a/backend/src/main/java/org/fungover/zipp/service/ReplayService.java
+++ b/backend/src/main/java/org/fungover/zipp/service/ReplayService.java
@@ -11,16 +11,28 @@ import java.util.List;
 public class ReplayService {
 
     private final Deque<String> buffer = new ArrayDeque<>();
-    private final int maxSize = 5;
+    private final int maxSize;
 
-    public void addEvent(String event) {
+    public ReplayService() {
+        this(5);
+    }
+
+    public ReplayService(int maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    public synchronized void addEvent(String event) {
         if (buffer.size() == maxSize) {
             buffer.removeFirst();
         }
         buffer.addLast(event);
     }
 
-    public List<String> getReplayEvents() {
+    public synchronized List<String> getReplayEvents() {
         return new ArrayList<>(buffer);
+    }
+
+    public synchronized void clear() {
+        buffer.clear();
     }
 }

--- a/backend/src/test/java/org/fungover/zipp/service/ReplayServiceTest.java
+++ b/backend/src/test/java/org/fungover/zipp/service/ReplayServiceTest.java
@@ -33,4 +33,34 @@ class ReplayServiceTest {
         assertTrue(replayed.contains("event6"));
         assertTrue(replayed.contains("event10"));
     }
+
+    @Test
+    void replayShouldReturnEmptyListWhenNoEventAdded() {
+        ReplayService replayService = new ReplayService();
+        List<String> replayed = replayService.getReplayEvents();
+        assertTrue(replayed.isEmpty());
+    }
+
+    @Test
+    void bufferShouldHoldExactlyMaxSize() {
+        ReplayService replayService = new ReplayService();
+        for (int i = 1; i <= 5; i++) {
+            replayService.addEvent("event" + i);
+        }
+        List<String> replayed = replayService.getReplayEvents();
+        assertEquals(5, replayed.size());
+        assertTrue(replayed.contains("event1"));
+        assertTrue(replayed.contains("event5"));
+    }
+
+    @Test
+    void replayShouldReturnEventsInOrder() {
+        ReplayService replayService = new ReplayService();
+        replayService.addEvent("event1");
+        replayService.addEvent("event2");
+        replayService.addEvent("event3");
+
+        List<String> replayed = replayService.getReplayEvents();
+        assertEquals(List.of("event1", "event2", "event3"), replayed);
+    }
 }


### PR DESCRIPTION
## Summary
Add support for replaying recent events when a client connects to the SSE endpoint.  
This implementation is **independent of the Event Listener** to keep history clean, but is intended to be easily integrated by calling `ReplayService.addEvent(...)` from the listener.

## Motivation
- Provides context to new SSE clients by replaying the last N events.
- Improves usability and robustness.
- Keeps the feature examiner‑friendly and reproducible without introducing dependencies.

## Changes
- Introduced `ReplayService` with buffer to store the last 5 events.
- Added unit tests to validate buffer behavior (size, order, empty state).
- Added integration tests with `@EmbeddedKafka` to confirm replay delivery.
- Updated SSE connection logic to send buffered events to new subscribers.

## Verification
- `mvn clean install` passes locally.
- Unit tests confirm buffer correctness.
- Integration tests confirm replayed events are delivered on client connection.

## Notes
- This feature is standalone from Event Listener (#7) but can be connected with a single call to `ReplayService.addEvent(...)`.
- Future enhancements may include configurable buffer size or filtering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event replay buffer functionality to maintain and retrieve recent events
  * Configurable storage capacity with a default limit of 5 events
  * Thread-safe implementation with automatic buffer management
  * Events preserved in insertion order for consistent retrieval

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->