### PR TITLE
Remove spring.profiles.active property that breaks our deployed webapp

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -37,7 +37,6 @@ server.servlet.session.cookie.secure=true
 spring.kafka.listener.type=single
 spring.kafka.listener.missing-topics-fatal=false
 
-spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
 # google maps
 google.maps.api.key=${GOOGLE_MAPS_API_KEY:dummy}
 


### PR DESCRIPTION
A line of code was removed! More details in the associated issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed default Spring profile activation. The application now requires explicit Spring profile configuration via environment variables or external settings instead of relying on a built-in default value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->