### PR TITLE
Fix(Config) Set default value for expirationHours

### DIFF
--- a/backend/src/main/java/org/fungover/zipp/config/ReportConfig.java
+++ b/backend/src/main/java/org/fungover/zipp/config/ReportConfig.java
@@ -9,7 +9,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "report")
 @Validated
 public class ReportConfig {
-    @Positive private long expirationHours;
+    @Positive private long expirationHours = 1;
 
     public long getExpirationHours() {
         return expirationHours;


### PR DESCRIPTION
🤞

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reports now have a default expiration time, ensuring proper resource management and preventing reports from persisting indefinitely when no custom expiration is configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->